### PR TITLE
[Fix] fix invalid index of a 0-dim tensor

### DIFF
--- a/model.py
+++ b/model.py
@@ -57,7 +57,7 @@ class Attention(nn.Module):
     def calculate_classification_error(self, X, Y):
         Y = Y.float()
         _, Y_hat, _ = self.forward(X)
-        error = 1. - Y_hat.eq(Y).cpu().float().mean().data[0]
+        error = 1. - Y_hat.eq(Y).cpu().float().mean().data.item()
 
         return error, Y_hat
 


### PR DESCRIPTION
Fix the bug of `invalid index of a 0-dim tensor` by replacing `data[0]` to `.item()`.
As:
```
error = 1. - Y_hat.eq(Y).cpu().float().mean().data[0]
```
to
```
error = 1. - Y_hat.eq(Y).cpu().float().mean().data.item()
```