### PR TITLE
[Improve] Rename model parameters to be like in the paper

### DIFF
--- a/model.py
+++ b/model.py
@@ -25,9 +25,9 @@ class Attention(nn.Module):
         )
 
         self.attention = nn.Sequential(
-            nn.Linear(self.M, self.L),
+            nn.Linear(self.M, self.L), # matrix V
             nn.Tanh(),
-            nn.Linear(self.L, self.ATTENTION_OUT)
+            nn.Linear(self.L, self.ATTENTION_OUT) # vector w
         )
 
         self.classifier = nn.Sequential(
@@ -91,16 +91,16 @@ class GatedAttention(nn.Module):
         )
 
         self.attention_V = nn.Sequential(
-            nn.Linear(self.M, self.L),
+            nn.Linear(self.M, self.L), # matrix V
             nn.Tanh()
         )
 
         self.attention_U = nn.Sequential(
-            nn.Linear(self.M, self.L),
+            nn.Linear(self.M, self.L), # # matrix U
             nn.Sigmoid()
         )
 
-        self.attention_w = nn.Linear(self.L, self.ATTENTION_OUT)
+        self.attention_w = nn.Linear(self.L, self.ATTENTION_OUT) # vector w
 
         self.classifier = nn.Sequential(
             nn.Linear(self.M*self.ATTENTION_OUT, 1),


### PR DESCRIPTION
Dear authors,

I reviewed your code and the paper to understand how the model works. I noticed that there were certain inconsistencies in how you named the dimensions in the network architectures. I think it would be helpful to have them named in the same way in both the code and the paper. I provide the mapping in the table below:

| Description        | Code                 | Paper |
| ------------------ | -------------------- | ----- |
| Bag size           | N                    | K     |
| Attention in_features        | L                    | M     |
| Matrix V           | D(out) x L(in)       | L(out) x M(in) |
| Vector w           | K(out) x D(in)       | L(in) x 1(out) |
| Attention internal_features | D                    | L     |
| Attention Branches (out_features)      | K                    | 1     |
| Weighted features  | Matrix M             | Vector Z |

Therefore, I made the following renamings:
* K -> ATTENTION_BRANCHES (parameter)
* N -> K (parameter)
* M -> Z (matrix)
* L -> M (parameter)
* D -> L (parameter)

**Testing:**

I tested the original and the new models (see screenshots). I created 4 model instances (original code, renamed code) x (Attention, Gated Attention). Then I tested that for the same architecture, given a fixed random seed:
1. The weights tensors are the same for the original and the renamed models
2. The output tensors are the same for the original and the renamed models

I think merging this pull request will make the code and the paper notation much more consistent and allow people to understand it much faster.

Kind regards,
George Batchkala

----

**Weights check**
![weights-check](https://github.com/AMLab-Amsterdam/AttentionDeepMIL/assets/46561186/90f5850b-119b-4ea7-b2a4-36a7354bff55)

----

**Attention outputs check**
![attention-outputs](https://github.com/AMLab-Amsterdam/AttentionDeepMIL/assets/46561186/32935aa7-2ae8-447c-9ddc-7bb82ab7c418)

----

**Gated attention outputs check**
![gated-attention-outputs](https://github.com/AMLab-Amsterdam/AttentionDeepMIL/assets/46561186/77d20506-937c-4af1-8fda-69bdd43b5357)
